### PR TITLE
Fix management command options

### DIFF
--- a/background_task/management/commands/process_tasks.py
+++ b/background_task/management/commands/process_tasks.py
@@ -35,13 +35,13 @@ class Command(BaseCommand):
         }),
         (('--log-file', ), {
             'action': 'store',
-            'dest': 'queue',
-            'help': 'Only process tasks on this named queue',
-        }),
-        (('--log-std', ), {
-            'action': 'store',
             'dest': 'log_file',
             'help': 'Log file destination',
+        }),
+        (('--log-std', ), {
+            'action': 'store_true',
+            'dest': 'log_std',
+            'help': 'Redirect stdout and stderr to the logging system',
         }),
         (('--log-level', ), {
             'action': 'store',


### PR DESCRIPTION
Commit fe7c908368f7c79883c76c21e87a1eef70691007 introduced a couple of small errors into process_tasks while adding Django 1.10-style option parsing. The result was that --log-file was overwriting --queue and there was no way to specify --log-std. This fixes those issues.
