### PR TITLE
Ensure that Task repetitions are created only in the future

### DIFF
--- a/background_task/models.py
+++ b/background_task/models.py
@@ -288,6 +288,8 @@ class Task(models.Model):
 
         args, kwargs = self.params()
         new_run_at = self.run_at + timedelta(seconds=self.repeat)
+        while new_run_at < timezone.now():
+            new_run_at += timedelta(seconds=self.repeat)
 
         new_task = TaskManager().new_task(
             task_name=self.task_name,


### PR DESCRIPTION
The idea of task repetitions is to repeat a task each n seconds.
This is fine for use-cases where task processing is always running.

When task processing is not always running, this can create a problem.
For example, imagine a daily task and the processing stopping for one week.
When the processing resumes, the same task will be run 7 times in short succession.

This PR ensures that task repetitions are only scheduled in the future.
For above example, this means that the 7 tasks will not be created.
Instead, only one new task will be created, preventing the same task
from running unnecessarily several times.

This PR also adds a unit test to ensure this behavior will not break
again in the future.

Closes #115