### PR TITLE
Add InvalidTaskError exception class

### DIFF
--- a/background_task/exceptions.py
+++ b/background_task/exceptions.py
@@ -6,3 +6,10 @@ class BackgroundTaskError(Exception):
     def __init__(self, message, errors=None):
         super(BackgroundTaskError, self).__init__(message)
         self.errors = errors
+
+
+class InvalidTaskError(BackgroundTaskError):
+	"""
+	The task will not be rescheduled if it fails with this error
+	"""
+	pass

--- a/background_task/models.py
+++ b/background_task/models.py
@@ -14,6 +14,7 @@ from django.db.models import Q
 from django.utils import timezone
 from django.utils.six import python_2_unicode_compatible
 
+from background_task.exceptions import InvalidTaskError
 from background_task.settings import app_settings
 from background_task.signals import task_failed, task_rescheduled
 
@@ -234,7 +235,7 @@ class Task(models.Model):
         '''
         self.last_error = self._extract_error(type, err, traceback)
         self.increment_attempts()
-        if self.has_reached_max_attempts():
+        if self.has_reached_max_attempts() or isinstance(err, InvalidTaskError):
             self.failed_at = timezone.now()
             logger.warning('Marking task %s as failed', self)
             completed = self.create_completed_task()


### PR DESCRIPTION
There are use cases when the running task itself determines that something is wrong and cannot be fixed, so there's no point in re-scheduling the task. But we still want to provide the user with information about errors.

One way to do it is to introduce an exception class that can be raised from a task function to mark the task as invalid so that it can be considered failed immediately.