### PR TITLE
remove "makemigrations" step from docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,7 +38,6 @@ Migrate your database:
 
 .. code-block:: sh
 
-    python manage.py makemigrations background_task
     python manage.py migrate
 
 Supported versions and compatibility


### PR DESCRIPTION
Why would you do that as a user? Isn't it?