### PR TITLE
Add documentation for remove_existing_tasks

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -127,6 +127,16 @@ You can pass a queue name to the ``background`` decorator:
 
 If you run the command ``process_tasks`` with the option ``--queue <queue_name>`` you can restrict the tasks processed to the given queue.
 
+Scheduling the same task twice
+==============================
+
+Normally, when you scheudle the exact same task twice, it will also be executed twice. If you want to remove existing tasks with the same parameters, you can set the parameter `remove_existing_tasks` to `True`:
+
+.. code-block:: python
+
+    @background(remove_existing_tasks=True)
+    def recalculate_data():
+        ...
 
 Running tasks
 =============


### PR DESCRIPTION
This feature was introduced in 47dc39b9a069225b4fba2c189f104316177ab164 but not documented.
Since I needed the feature and couldn't find it in the docs, I figured I could send you a small patch.