### PR TITLE
yes/no instead of green/red icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ target/
 
 test_db
 .idea
+*.iml

--- a/background_task/admin.py
+++ b/background_task/admin.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 from django.contrib import admin
-from background_task.models import Task
-from background_task.models import CompletedTask
+
+from background_task.models import Task, CompletedTask
+from background_task.settings import app_settings
 
 
 def inc_priority(modeladmin, request, queryset):
@@ -16,17 +17,41 @@ def dec_priority(modeladmin, request, queryset):
         obj.save()
 dec_priority.short_description = "priority -= 1"
 
+if app_settings.BACKGROUND_TASK_BOOLEAN_AS_TEXT:
+    def boolean_display(b):
+        if b is None:
+            return
+        elif b:
+            return 'Yes'
+        else:
+            return 'No'
+
+    def has_error(task):
+        return boolean_display(task.has_error())
+
+    def locked_by_pid_running(task):
+        return boolean_display(task.locked_by_pid_running())
+else:
+    def has_error(task):
+        return task.has_error()
+    has_error.boolean = True
+
+    def locked_by_pid_running(task):
+        return task.locked_by_pid_running()
+    locked_by_pid_running.boolean = True
+
 class TaskAdmin(admin.ModelAdmin):
     display_filter = ['task_name']
     search_fields = ['task_name', 'task_params', ]
-    list_display = ['task_name', 'task_params', 'run_at', 'priority', 'attempts', 'has_error', 'locked_by', 'locked_by_pid_running', ]
+    list_display = ['task_name', 'task_params', 'run_at', 'priority', 'attempts', has_error, 'locked_by',
+                    locked_by_pid_running, ]
     actions = [inc_priority, dec_priority]
 
 class CompletedTaskAdmin(admin.ModelAdmin):
     display_filter = ['task_name']
     search_fields = ['task_name', 'task_params', ]
-    list_display = ['task_name', 'task_params', 'run_at', 'priority', 'attempts', 'has_error', 'locked_by', 'locked_by_pid_running', ]
-
+    list_display = ['task_name', 'task_params', 'run_at', 'priority', 'attempts', has_error, 'locked_by',
+                    locked_by_pid_running, ]
 
 admin.site.register(Task, TaskAdmin)
 admin.site.register(CompletedTask, CompletedTaskAdmin)

--- a/background_task/settings.py
+++ b/background_task/settings.py
@@ -58,4 +58,9 @@ class AppSettings(object):
             prefix = '-'
         return prefix
 
+    @property
+    def BACKGROUND_TASK_BOOLEAN_AS_TEXT(self):
+        """Control how status booleans are displayed in the admin."""
+        return getattr(settings, 'BACKGROUND_TASK_BOOLEAN_AS_TEXT', False)
+
 app_settings = AppSettings()


### PR DESCRIPTION
In the django admin when a tasks failed the 'has_error' field shows a happy green icon (and when the task succeeded a scary red icon).

This commit replaces the green/red icons by more neutral 'Yes' and 'No' words. Both for the 'has_error' and 'locked_by_pid_running' fields.
