### PR TITLE
SignalManager: sigterm and sigint for linux system

### DIFF
--- a/background_task/utils.py
+++ b/background_task/utils.py
@@ -17,6 +17,8 @@ class SignalManager(object):
         if platform.system() == 'Windows':
             signal.signal(signal.SIGTERM, self.exit_gracefully)
         else:
+            signal.signal(signal.SIGTERM, self.exit_gracefully)
+            signal.signal(signal.SIGINT, self.exit_gracefully)
             signal.signal(signal.SIGTSTP, self.exit_gracefully)
             signal.signal(signal.SIGUSR1, self.speed_up)
             signal.signal(signal.SIGUSR2, self.slow_down)


### PR DESCRIPTION
Hey!

I just add sigterm and sigint signal in the signal manager class.

Before that when you sent ctrl+c in linux the program was killed and if there were a task running, it wasn't unlocked and stay in the task model forever because it was locked.
This is why I made this pull requests.

Thanks you for this awesome django package.

Hoping that you will validate this.