### PR TITLE
Feature/autoreload

### DIFF
--- a/background_task/management/commands/process_tasks.py
+++ b/background_task/management/commands/process_tasks.py
@@ -60,7 +60,7 @@ class Command(BaseCommand):
         (('--dev', ), {
             'action': 'store_true',
             'dest': 'dev',
-            'help': 'Developement server: autoreload files on change as runserver',
+            'help': 'Auto-reload your code on changes. Use this only for development',
         }),
     )
 

--- a/background_task/management/commands/process_tasks.py
+++ b/background_task/management/commands/process_tasks.py
@@ -6,6 +6,7 @@ import time
 
 from django import VERSION
 from django.core.management.base import BaseCommand
+from django.utils import autoreload
 
 from background_task.tasks import tasks, autodiscover
 from background_task.utils import SignalManager
@@ -56,7 +57,11 @@ class Command(BaseCommand):
             'dest': 'log_std',
             'help': 'Redirect stdout and stderr to the logging system',
         }),
-
+        (('--dev', ), {
+            'action': 'store_true',
+            'dest': 'dev',
+            'help': 'Developement server: autoreload files on change as runserver',
+        }),
     )
 
     if VERSION < (1, 8):
@@ -70,14 +75,15 @@ class Command(BaseCommand):
 
     def __init__(self, *args, **kwargs):
         super(Command, self).__init__(*args, **kwargs)
+        self.sig_manager = SignalManager()
         self._tasks = tasks
 
-    def handle(self, *args, **options):
+    def run(self, *args, **options):
         duration = options.pop('duration', 0)
         sleep = options.pop('sleep', 5.0)
         queue = options.pop('queue', None)
         log_std = options.pop('log_std', False)
-        sig_manager = SignalManager()
+        sig_manager = self.sig_manager
 
         if log_std:
             _configure_log_std()
@@ -99,3 +105,13 @@ class Command(BaseCommand):
             else:
                 # there were some tasks to process, let's check if there is more work to do after a little break.
                 time.sleep(random.uniform(sig_manager.time_to_wait[0], sig_manager.time_to_wait[1]))
+
+    def handle(self, *args, **options):
+        dev_server = options.pop('dev', False)
+        if dev_server:
+            reload_func = autoreload.run_with_reloader
+            if VERSION < (2, 2):
+                reload_func = autoreload.main
+            reload_func(self.run, args=args, kwargs=options)
+        else:
+            self.run(*args, **options)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -154,6 +154,7 @@ The ``process_tasks`` management command has the following options:
 * ``duration`` - Run task for this many seconds (0 or less to run forever) - default is 0
 * ``sleep`` - Sleep for this many seconds before checking for new tasks (if none were found) - default is 5
 * ``log-std`` - Redirect stdout and stderr to the logging system
+* ``dev`` - Auto-reload your code on changes. Use this only for development
 
 You can use the ``duration`` option for simple process control, by running the management command via a cron job and setting the duration to the time till cron calls the command again.  This way if the command fails it will get restarted by the cron job later anyway.  It also avoids having to worry about resource/memory leaks too much.  The alternative is to use a grown-up program like supervisord_ to handle this for you.
 


### PR DESCRIPTION
Hey!

As I promised.
Here is a new argument to `` process_taks``: `` --dev``.
It will launch the task manager with autoreload (from django.utils) exactly as runserver does.

### what I have done
- add ``dev`` option
- use autoreload.main for django < 2.2 and autoreload.run_with_reloader fro django >= 2.2
- use get instead of pop to get parameters
- initialize the signal manager before calling autoreload
- update doc


#195 