### PR TITLE
Replace django.utils.six with six to support Django 3.0

### DIFF
--- a/background_task/models.py
+++ b/background_task/models.py
@@ -12,7 +12,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.db.models import Q
 from django.utils import timezone
-from django.utils.six import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 
 from background_task.exceptions import InvalidTaskError
 from background_task.settings import app_settings

--- a/background_task/models_completed.py
+++ b/background_task/models_completed.py
@@ -6,7 +6,7 @@ from django.contrib.contenttypes.models import ContentType
 
 from django.db import models
 from django.utils import timezone
-from django.utils.six import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 
 from background_task.models import Task
 

--- a/background_task/tasks.py
+++ b/background_task/tasks.py
@@ -10,7 +10,7 @@ import sys
 
 from django.db.utils import OperationalError
 from django.utils import timezone
-from django.utils.six import python_2_unicode_compatible
+from six import python_2_unicode_compatible
 
 from background_task.exceptions import BackgroundTaskError
 from background_task.models import Task


### PR DESCRIPTION
Django 3.0 was released a few days ago, and as per the [release notes](https://docs.djangoproject.com/en/3.0/releases/3.0/#removed-private-python-2-compatibility-apis):

> django.utils.six - Remove usage of this vendored library or switch to six.

This just does that fix (switches to `six` instead of `django.utils.six`) so that this library can run on Django 3.0.