### PR TITLE
Feature custom delay between attempts

### DIFF
--- a/background_task/settings.py
+++ b/background_task/settings.py
@@ -28,7 +28,8 @@ class AppSettings(object):
         Control the delay between each attempt (expressed in seconds). It can be either:
 
         * an integer;
-        * a callable that receive one argument - the number of attempts done after the current run.
+        * a callable that receives one and only argument - the number of attempts done after the current run - and
+        returns an integer.
 
         Default value: lambda attempts: (attempts ** 4) + 5
         """

--- a/background_task/settings.py
+++ b/background_task/settings.py
@@ -23,6 +23,18 @@ class AppSettings(object):
         return self.MAX_ATTEMPTS
 
     @property
+    def BACKGROUND_TASK_DELAY_BETWEEN_ATTEMPTS(self):
+        """
+        Control the delay between each attempt (expressed in seconds). It can be either:
+
+        * an integer;
+        * a callable that receive one argument - the number of attempts done after the current run.
+
+        Default value: lambda attempts: (attempts ** 4) + 5
+        """
+        return getattr(settings, 'BACKGROUND_TASK_DELAY_BETWEEN_ATTEMPTS', lambda attempts: (attempts ** 4) + 5)
+
+    @property
     def MAX_RUN_TIME(self):
         """Maximum possible task run time, after which tasks will be unlocked and tried again."""
         return getattr(settings, 'MAX_RUN_TIME', 3600)
@@ -57,5 +69,6 @@ class AppSettings(object):
         else:
             prefix = '-'
         return prefix
+
 
 app_settings = AppSettings()


### PR DESCRIPTION
The default repeating delay between task errors is very interesting but for the sake of consistency between our apps, we need to set a fixed delay of 15 minutes.

In order to keep the original feature and to allow more control on the delay, this PR adds a new setting variable (named `BACKGROUND_TASK_DELAY_BETWEEN_ATTEMPTS`), along with the suitable unit tests. The documentation has also been updated.