### PR TITLE
Add option to restart failed tasks

### DIFF
--- a/background_task/admin.py
+++ b/background_task/admin.py
@@ -16,16 +16,24 @@ def dec_priority(modeladmin, request, queryset):
         obj.save()
 dec_priority.short_description = "priority -= 1"
 
+def restart_completed(modeladmin, request, queryset):
+    for obj in queryset:
+        obj.create_restarted_task()
+restart_completed.short_description = "Restart selected completed tasks"
+
 class TaskAdmin(admin.ModelAdmin):
     display_filter = ['task_name']
     search_fields = ['task_name', 'task_params', ]
     list_display = ['task_name', 'task_params', 'run_at', 'priority', 'attempts', 'has_error', 'locked_by', 'locked_by_pid_running', ]
+    list_filter = ['task_name', 'has_error']
     actions = [inc_priority, dec_priority]
 
 class CompletedTaskAdmin(admin.ModelAdmin):
     display_filter = ['task_name']
     search_fields = ['task_name', 'task_params', ]
     list_display = ['task_name', 'task_params', 'run_at', 'priority', 'attempts', 'has_error', 'locked_by', 'locked_by_pid_running', ]
+    list_filter = ['task_name', 'has_error']
+    actions = [restart_completed]
 
 
 admin.site.register(Task, TaskAdmin)

--- a/background_task/models.py
+++ b/background_task/models.py
@@ -439,6 +439,22 @@ class CompletedTask(models.Model):
         return bool(self.last_error)
     has_error.boolean = True
 
+    def create_restarted_task(self):
+        restarted_task = Task(
+            task_name=self.task_name,
+            task_params=self.task_params,
+            task_hash=self.task_hash,
+            priority=self.priority,
+            run_at=timezone.now(),
+            queue=self.queue,
+            verbose_name=self.verbose_name,
+            creator=self.creator,
+            repeat=self.repeat,
+            repeat_until=self.repeat_until,
+        )
+        restarted_task.save()
+        return restarted_task
+
     def __str__(self):
         return u'{} - {}'.format(
             self.verbose_name or self.task_name,


### PR DESCRIPTION
I frequenty face the issue that a failed completed task needs to be restarted. Currently it is only possible from code, but in a cloud environment is it not convenient. I propose to add an admin action to restart completed jobs.

I also added filtering options to list views of the admin pages.