### PR TITLE
Fix RemovedInDjango40Warning in signals.py

### DIFF
--- a/background_task/signals.py
+++ b/background_task/signals.py
@@ -3,11 +3,11 @@ import django.dispatch
 from django.db import connections
 from background_task.settings import app_settings
 
-task_created = django.dispatch.Signal(providing_args=['task'])
-task_error = django.dispatch.Signal(providing_args=['task'])
-task_rescheduled = django.dispatch.Signal(providing_args=['task'])
-task_failed = django.dispatch.Signal(providing_args=['task_id', 'completed_task'])
-task_successful = django.dispatch.Signal(providing_args=['task_id', 'completed_task'])
+task_created = django.dispatch.Signal()
+task_error = django.dispatch.Signal()
+task_rescheduled = django.dispatch.Signal()
+task_failed = django.dispatch.Signal()
+task_successful = django.dispatch.Signal()
 task_started = django.dispatch.Signal()
 task_finished = django.dispatch.Signal()
 


### PR DESCRIPTION
When running pytest against Django 3.1 I get 5 of these warnings:

```
=============================== warnings summary ===============================
.venv/lib/python3.8/site-packages/background_task/signals.py:6
  /Users/james/journee-git/journee-django/.venv/lib/python3.8/site-packages/background_task/signals.py:6: RemovedInDjango40Warning: The providing_args argument is deprecated. As it is purely documentational, it has no replacement. If you rely on this argument as documentation, you can move the text to a code comment or docstring.
    task_created = django.dispatch.Signal(providing_args=['task'])
```

As the message says, providing_args can simple be removed without consequence. I've done this and all the warnings are now fixed.